### PR TITLE
Update BT to respect actor ID and visibility state

### DIFF
--- a/battletracker/battletracker.xml
+++ b/battletracker/battletracker.xml
@@ -72,6 +72,11 @@
 					function onSortCompare(w1, w2)
 						return CombatManager.onSortCompare(w1.getDatabaseNode(), w2.getDatabaseNode());
 					end
+
+					function onFilter(w)
+						local bVisible = DB.getValue(w.getDatabaseNode(), "tokenvis", 0) == 1;
+						return bVisible or Session.IsHost;
+					end
 				</script>
 				<class>battletracker_commander</class>
 				<empty font="list-empty-ct" textres="ct_emptylist" />
@@ -218,6 +223,15 @@
 					<right parent="rightanchor" anchor="left" relation="relative" offset="-7" />
 				</anchored>
 				<empty textres="unknown_commander" />
+			</string_ctname>
+			<string_ctname name="nonid_name">
+				<empty textres="library_recordtype_empty_nonid_npc" />
+				<anchored merge="replace" height="20">
+					<left parent="leftanchor" anchor="right" relation="relative" offset="7" />
+					<top offset="7" />
+					<right parent="rightanchor" anchor="left" relation="relative" offset="-7" />
+				</anchored>
+				<invisible />
 			</string_ctname>
 
 			<battletracker_unitlist/>

--- a/battletracker/scripts/battletracker.lua
+++ b/battletracker/scripts/battletracker.lua
@@ -10,6 +10,7 @@ function onInit()
 	end
 
 	DB.addHandler(CombatManager.CT_COMBATANT_PATH, "onDelete", onDeleted);
+	DB.addHandler(DB.getPath(CombatManager.CT_COMBATANT_PATH, "tokenvis"), "onUpdate", onTokenVisChanged);
 
 	CombatManagerKw.registerCombatantAddedHandler(combatantAdded);
 	CombatManagerKw.registerUnitSelectionHandler(primaryUnitSelected, 1);
@@ -19,10 +20,13 @@ function onInit()
 	if Session.IsHost and UtilityManager.isClientFGU() then
 		User.onIdentityStateChange = onIdentityStateChange;
 	end
+
+	onTokenVisChanged();
 end
 
 function onClose()
 	DB.removeHandler(CombatManager.CT_COMBATANT_PATH, "onDelete", onDeleted);
+	DB.removeHandler(DB.getPath(CombatManager.CT_COMBATANT_PATH, "tokenvis"), "onUpdate", onTokenVisChanged);
 	
 	CombatManagerKw.unregisterCombatantAddedHandler(combatantAdded);
 	CombatManagerKw.unregisterUnitSelectionHandler(primaryUnitSelected, 1);
@@ -229,4 +233,8 @@ function secondaryUnitSelected(nodeUnit)
 	if primary_selected_unit.subwindow and primary_selected_unit.subwindow.getDatabaseNode() == nodeUnit then
 		primary_selected_unit.setValue("battletracker_emptysummary");
 	end
+end
+
+function onTokenVisChanged()
+	list.applyFilter()
 end

--- a/battletracker/scripts/commander.lua
+++ b/battletracker/scripts/commander.lua
@@ -9,8 +9,10 @@ function onInit()
 	DB.addHandler(node.getPath("friendfoe"), "onUpdate", onFactionUpdated);
 	DB.addHandler(node.getPath("active"), "onUpdate", updateDisplay);
 	DB.addHandler(node.getPath(), "onDelete", onDelete);
+	DB.addHandler(node.getPath("isidentified"), "onUpdate", onIDChanged);
 
 	updateDisplay();
+	onIDChanged();
 	
 	-- Initialize color
 	if Session.IsHost and node then
@@ -36,6 +38,7 @@ function onClose()
 	DB.removeHandler(node.getPath("friendfoe"), "onUpdate", onFactionUpdated);
 	DB.removeHandler(node.getPath("active"), "onUpdate", updateDisplay);
 	DB.removeHandler(node.getPath(), "onDelete", onDelete);
+	DB.removeHandler(node.getPath("isidentified"), "onUpdate", onIDChanged);
 end
 
 -- Listen to its own delete event so it can neatly delete all of its units. Could also have the units set their commanders to nil.
@@ -134,5 +137,18 @@ function onDrop(x, y, draginfo)
 	elseif sClass == "reference_unit" then
 		CombatManagerKw.setUnitDropCommander(getDatabaseNode());
 		return CampaignDataManager.handleDrop("combattracker", draginfo);
+	end
+end
+
+function onIDChanged()
+	local nodeRecord = getDatabaseNode();
+	local sClass = DB.getValue(nodeRecord, "link", "", "");
+	if sClass == "npc" then
+		local bID = LibraryData.getIDState("npc", nodeRecord, true);
+		name.setVisible(bID);
+		nonid_name.setVisible(not bID);
+	else
+		name.setVisible(true);
+		nonid_name.setVisible(false);
 	end
 end

--- a/battletracker/scripts/unitsummary.lua
+++ b/battletracker/scripts/unitsummary.lua
@@ -14,9 +14,9 @@ function onInit()
 	DB.addHandler(DB.getPath(nodeUnit, "ancestry"), "onUpdate", updateSummary);
 	DB.addHandler(DB.getPath(nodeUnit, "type"), "onUpdate", updateSummary);
 
-	nodeUnit = getDatabaseNode(); -- Color is only tracked in the CT node
-	onColorChanged(DB.getChild(nodeUnit, "color"));
-	DB.addHandler(DB.getPath(nodeUnit, "color"), "onUpdate", onColorChanged);
+	-- Color and ID are only tracked in the CT node
+	onColorChanged(DB.getChild(getDatabaseNode(), "color"));
+	DB.addHandler(DB.getPath(getDatabaseNode(), "color"), "onUpdate", onColorChanged);
 
 	if FriendZone then
 		linkFields();
@@ -24,11 +24,14 @@ function onInit()
 end
 
 function onClose()
+	local nodeUnit = link.getTargetDatabaseNode(); -- Build the summary of the linked node
 	DB.removeHandler(DB.getPath(nodeUnit, "tier"), "onUpdate", updateSummary);
 	DB.removeHandler(DB.getPath(nodeUnit, "experience"), "onUpdate", updateSummary);
 	DB.removeHandler(DB.getPath(nodeUnit, "armor"), "onUpdate", updateSummary);
 	DB.removeHandler(DB.getPath(nodeUnit, "ancestry"), "onUpdate", updateSummary);
 	DB.removeHandler(DB.getPath(nodeUnit, "type"), "onUpdate", updateSummary);
+
+	DB.removeHandler(DB.getPath(getDatabaseNode(), "color"), "onUpdate", onColorChanged);
 end
 
 function linkFields()

--- a/battletracker/scripts/unitsummary.lua
+++ b/battletracker/scripts/unitsummary.lua
@@ -3,8 +3,6 @@
 -- attribution and copyright information.
 --
 
-local nodeUnit;
-
 function onInit()
 	updateSummary();
 	local nodeUnit = link.getTargetDatabaseNode(); -- Build the summary of the linked node
@@ -15,8 +13,9 @@ function onInit()
 	DB.addHandler(DB.getPath(nodeUnit, "type"), "onUpdate", updateSummary);
 
 	-- Color and ID are only tracked in the CT node
-	onColorChanged(DB.getChild(getDatabaseNode(), "color"));
-	DB.addHandler(DB.getPath(getDatabaseNode(), "color"), "onUpdate", onColorChanged);
+	local nodeCT = getDatabaseNode();
+	onColorChanged(DB.getChild(nodeCT, "color"));
+	DB.addHandler(DB.getPath(nodeCT, "color"), "onUpdate", onColorChanged);
 
 	if FriendZone then
 		linkFields();

--- a/battletracker/template_battletracker.xml
+++ b/battletracker/template_battletracker.xml
@@ -31,7 +31,7 @@
 			</script>
 			<anchored>
 				<left />
-				<top parent="name" anchor="bottom" offset="7" />
+				<top parent="" offset="34" />
 				<right />
 			</anchored>
 			<class>battletracker_unit</class>


### PR DESCRIPTION
Updated the battle tracker so that commanders now display either their ID or non-ID name depending on their CT state. Also the BT now hides invisible actors from clients.