### PR TITLE
Unit stat updater

### DIFF
--- a/campaign/record_unit.xml
+++ b/campaign/record_unit.xml
@@ -266,8 +266,22 @@
 			<cycler_columnh name="experience">
 				<anchored width="150" />
 				<script>
+					local fCycleLabel;
+					local sPrevValue;
+					function onInit()
+						super.onInit();
+						fCycleLabel = super.super.cycleLabel;
+						super.super.cycleLabel = cycleLabel;
+					end
+					function cycleLabel(bBackward)
+						if getValue() ~= "-" then
+							sPrevValue = getValue();
+						end
+						fCycleLabel(bBackward)
+					end
 					function onValueChanged()
 						window.onSummaryChanged();
+						window.updateExperience(sPrevValue, getValue());
 					end
 				</script>
 				<parameters>
@@ -284,8 +298,22 @@
 			<cycler_columnh name="armor">
 				<anchored width="150" />
 				<script>
+					local fCycleLabel;
+					local sPrevValue;
+					function onInit()
+						super.onInit();
+						fCycleLabel = super.super.cycleLabel;
+						super.super.cycleLabel = cycleLabel;
+					end
+					function cycleLabel(bBackward)
+						if getValue() ~= "-" then
+							sPrevValue = getValue();
+						end
+						fCycleLabel(bBackward)
+					end
 					function onValueChanged()
 						window.onSummaryChanged();
+						window.updateArmor(sPrevValue, getValue());
 					end
 				</script>
 				<parameters>
@@ -314,8 +342,22 @@
 			<cycler_columnh name="type">
 				<anchored width="150" />
 				<script>
+					local fCycleLabel;
+					local sPrevValue;
+					function onInit()
+						super.onInit();
+						fCycleLabel = super.super.cycleLabel;
+						super.super.cycleLabel = cycleLabel;
+					end
+					function cycleLabel(bBackward)
+						if getValue() ~= "-" then
+							sPrevValue = getValue();
+						end
+						fCycleLabel(bBackward)
+					end
 					function onValueChanged()
 						window.onSummaryChanged();
+						window.updateType(sPrevValue, getValue());
 					end
 				</script>
 				<parameters>

--- a/campaign/scripts/unit_main.lua
+++ b/campaign/scripts/unit_main.lua
@@ -164,3 +164,84 @@ function addTrait(sName, sDesc)
 		w.desc.setValue(sDesc);
 	end
 end
+
+function updateExperience(sPrev, sCur)
+	if OptionsManager.getOption("AAUS") ~= "on" then
+		return;
+	end
+	local sType = type.getValue();
+	local prevStats = DataKW.getUnitExperienceStats(sType, sPrev)
+	local curStats = DataKW.getUnitExperienceStats(sType, sCur)
+
+	if curStats == nil or prevStats == nil then
+		return
+	end
+
+	local dAttacks = curStats["numberOfAttacks"] - prevStats["numberOfAttacks"];
+	local dAttack = curStats["attack"] - prevStats["attack"];
+	local dDefense = curStats["defense"] - prevStats["defense"];
+	local dMorale = curStats["morale"] - prevStats["morale"];
+	local dCommand = curStats["command"] - prevStats["command"];
+	
+	attacks.setValue(attacks.getValue() + dAttacks);
+	attack.setValue(attack.getValue() + dAttack);
+	defense.setValue(defense.getValue() + dDefense);
+	morale.setValue(morale.getValue() + dMorale);
+	command.setValue(command.getValue() + dCommand);
+end
+
+function updateArmor(sPrev, sCur)
+	if OptionsManager.getOption("AAUS") ~= "on" then
+		return;
+	end
+	local sType = type.getValue();
+	local prevStats = DataKW.getUnitEquipmentStats(sType, sPrev)
+	local curStats = DataKW.getUnitEquipmentStats(sType, sCur)
+
+	if curStats == nil or prevStats == nil then
+		return
+	end
+
+	local dPower = curStats["power"] - prevStats["power"];
+	local dToughness = curStats["toughness"] - prevStats["toughness"];
+	local dDamage = curStats["damage"] - prevStats["damage"];
+	
+	power.setValue(power.getValue() + dPower);
+	toughness.setValue(toughness.getValue() + dToughness);
+	damage.setValue(damage.getValue() + dDamage);
+end
+
+-- This one gets gnarly
+function updateType(sPrev, sCur)
+	if OptionsManager.getOption("AAUS") ~= "on" then
+		return;
+	end
+	local sExperience = experience.getValue();
+	local sArmor = armor.getValue();
+	local prevExp = DataKW.getUnitExperienceStats(sPrev, sExperience)
+	local curExp = DataKW.getUnitExperienceStats(sCur, sExperience)
+	local prevArmor = DataKW.getUnitEquipmentStats(sPrev, sArmor)
+	local curArmor = DataKW.getUnitEquipmentStats(sCur, sArmor)
+
+	if prevExp == nil or curExp == nil or prevArmor == nil or curArmor == nil then
+		return
+	end
+
+	local dAttacks = curExp["numberOfAttacks"] - prevExp["numberOfAttacks"];
+	local dAttack = curExp["attack"] - prevExp["attack"];
+	local dDefense = curExp["defense"] - prevExp["defense"];
+	local dMorale = curExp["morale"] - prevExp["morale"];
+	local dCommand = curExp["command"] - prevExp["command"];
+	local dPower = curArmor["power"] - prevArmor["power"];
+	local dToughness = curArmor["toughness"] - prevArmor["toughness"];
+	local dDamage = curArmor["damage"] - prevArmor["damage"];
+	
+	attacks.setValue(attacks.getValue() + dAttacks);
+	attack.setValue(attack.getValue() + dAttack);
+	defense.setValue(defense.getValue() + dDefense);
+	morale.setValue(morale.getValue() + dMorale);
+	command.setValue(command.getValue() + dCommand);
+	power.setValue(power.getValue() + dPower);
+	toughness.setValue(toughness.getValue() + dToughness);
+	damage.setValue(damage.getValue() + dDamage);
+end

--- a/scripts/data_kw.lua
+++ b/scripts/data_kw.lua
@@ -142,3 +142,263 @@ colors = {
 	["FF6600D2"] = true,
 	["FFFF7D04"] = true,
 }
+
+unit_experience = {
+	["infantry"] = {
+		["levies"] = {
+			["numberOfAttacks"] = 0,
+			["attack"] = -1,
+			["defense"] = -2,
+			["morale"] = -2,
+			["command"]= -1,
+		},
+		["regular"] = {
+			["numberOfAttacks"] = 0,
+			["attack"] = 0,
+			["defense"] = 0,
+			["morale"] = 0,
+			["command"]= 1,
+		},
+		["veteran"]= {
+			["numberOfAttacks"] = 0,
+			["attack"] = 1,
+			["defense"] = 2,
+			["morale"] = 2,
+			["command"]= 2,
+		},
+		["elite"] = {
+			["numberOfAttacks"] = 1,
+			["attack"] = 2,
+			["defense"] = 4,
+			["morale"] = 4,
+			["command"]= 2,
+		},
+		["super-elite"] = {
+			["numberOfAttacks"] = 1,
+			["attack"] = 3,
+			["defense"] = 6,
+			["morale"] = 6,
+			["command"]= 3,
+		},
+	},
+	["cavalry"] = {
+		["levies"] = {
+			["numberOfAttacks"] = 0,
+			["attack"] = 0,
+			["defense"] = 0,
+			["morale"] = 0,
+			["command"]= 0,
+		},
+		["regular"] = {
+			["numberOfAttacks"] = 0,
+			["attack"] = 0,
+			["defense"] = 0,
+			["morale"] = 0,
+			["command"]= 0,
+		},
+		["veteran"]= {
+			["numberOfAttacks"] = 0,
+			["attack"] = 1,
+			["defense"] = 1,
+			["morale"] = 1,
+			["command"]= 2,
+		},
+		["elite"] = {
+			["numberOfAttacks"] = 1,
+			["attack"] = 2,
+			["defense"] = 2,
+			["morale"] = 2,
+			["command"]= 4,
+		},
+		["super-elite"] = {
+			["numberOfAttacks"] = 1,
+			["attack"] = 3,
+			["defense"] = 3,
+			["morale"] = 3,
+			["command"]= 6,
+		},
+	},
+	["aerial"] = {
+		["levies"] = {
+			["numberOfAttacks"] = 0,
+			["attack"] = 0,
+			["defense"] = 0,
+			["morale"] = 0,
+			["command"]= 0,
+		},
+		["regular"] = {
+			["numberOfAttacks"] = 0,
+			["attack"] = 0,
+			["defense"] = 0,
+			["morale"] = 0,
+			["command"]= 0,
+		},
+		["veteran"]= {
+			["numberOfAttacks"] = 0,
+			["attack"] = 1,
+			["defense"] = 1,
+			["morale"] = 1,
+			["command"]= 2,
+		},
+		["elite"] = {
+			["numberOfAttacks"] = 1,
+			["attack"] = 2,
+			["defense"] = 2,
+			["morale"] = 2,
+			["command"]= 4,
+		},
+		["super-elite"] = {
+			["numberOfAttacks"] = 1,
+			["attack"] = 3,
+			["defense"] = 3,
+			["morale"] = 3,
+			["command"]= 6,
+		},
+	},
+	["artillery"] = {
+		["levies"] = {
+			["numberOfAttacks"] = 0,
+			["attack"] = 0,
+			["defense"] = 0,
+			["morale"] = 0,
+			["command"]= 0,
+		},
+		["regular"] = {
+			["numberOfAttacks"] = 0,
+			["attack"] = 0,
+			["defense"] = 0,
+			["morale"] = 0,
+			["command"]= 0,
+		},
+		["veteran"]= {
+			["numberOfAttacks"] = 1,
+			["attack"] = 2,
+			["defense"] = 1,
+			["morale"] = 1,
+			["command"]= 1,
+		},
+		["elite"] = {
+			["numberOfAttacks"] = 1,
+			["attack"] = 4,
+			["defense"] = 2,
+			["morale"] = 2,
+			["command"]= 2,
+		},
+		["super-elite"] = {
+			["numberOfAttacks"] = 1,
+			["attack"] = 6,
+			["defense"] = 3,
+			["morale"] = 3,
+			["command"]= 3,
+		},
+	}
+}
+
+unit_equipment = {
+	["infantry"] = {
+		["light"] = {
+			["power"] = 0,
+			["toughness"] = 0,
+			["damage"] = 0
+		},
+		["medium"] = {
+			["power"] = 2,
+			["toughness"] = 2,
+			["damage"] = 0
+		},
+		["heavy"] = {
+			["power"] = 4,
+			["toughness"] = 4,
+			["damage"] = 0
+		},
+		["super-heavy"] = {
+			["power"] = 6,
+			["toughness"] = 6,
+			["damage"] = 1
+		}
+	},
+	["cavalry"] = {
+		["light"] = {
+			["power"] = 0,
+			["toughness"] = 0,
+			["damage"] = 0
+		},
+		["medium"] = {
+			["power"] = 1,
+			["toughness"] = 1,
+			["damage"] = 0
+		},
+		["heavy"] = {
+			["power"] = 2,
+			["toughness"] = 2,
+			["damage"] = 0
+		},
+		["super-heavy"] = {
+			["power"] = 3,
+			["toughness"] = 3,
+			["damage"] = 1
+		}
+	},
+	["aerial"] = {
+		["light"] = {
+			["power"] = 0,
+			["toughness"] = 0,
+			["damage"] = 0
+		},
+		["medium"] = {
+			["power"] = 1,
+			["toughness"] = 1,
+			["damage"] = 0
+		},
+		["heavy"] = {
+			["power"] = 2,
+			["toughness"] = 2,
+			["damage"] = 0
+		},
+		["super-heavy"] = {
+			["power"] = 3,
+			["toughness"] = 3,
+			["damage"] = 1
+		}
+	},
+	["artillery"] = {
+		["light"] = {
+			["power"] = 0,
+			["toughness"] = 0,
+			["damage"] = 0
+		},
+		["medium"] = {
+			["power"] = 1,
+			["toughness"] = 1,
+			["damage"] = 0
+		},
+		["heavy"] = {
+			["power"] = 2,
+			["toughness"] = 2,
+			["damage"] = 0
+		},
+		["super-heavy"] = {
+			["power"] = 3,
+			["toughness"] = 3,
+			["damage"] = 0
+		}
+	}
+}
+
+function getUnitExperienceStats(sUnitType, sExperience)
+	local unit = unit_experience[sUnitType:lower()];
+	if unit and unit[sExperience:lower()] then
+		return unit[sExperience:lower()];
+	end
+
+	return nil;
+end
+
+function getUnitEquipmentStats(sUnitType, sEquipment)
+	local unit = unit_equipment[sUnitType:lower()];
+	if unit and unit[sEquipment:lower()] then
+		return unit[sEquipment:lower()];
+	end
+
+	return nil;
+end

--- a/scripts/data_options_kw.lua
+++ b/scripts/data_options_kw.lua
@@ -17,4 +17,6 @@ function registerOptions()
 	-- How should Demons' Souls be calculated when adding to the CT
 	OptionsManager.registerOption2("DSCT", false, "option_header_kw", "option_label_DSCT", "option_entry_cycler", 
 		{ labels = "option_val_max|option_val_random", values = "max|random", baselabel = "option_val_standard", baseval = "off", default = "off" });
+	OptionsManager.registerOption2("AAUS", false, "option_header_kw", "option_label_AAUS", "option_entry_cycler", 
+		{ labels = "option_val_on", values = "on", baselabel = "option_val_off", baseval = "off", default = "off" });
 end

--- a/scripts/manager_action_damage_kw.lua
+++ b/scripts/manager_action_damage_kw.lua
@@ -153,7 +153,6 @@ end
 
 function handleApplyDamage(msgOOB)
 	CombatManagerKw.pushListMode(CombatManagerKw.LIST_MODE_BOTH);
-	Debug.chat(msgOOB);
 	fHandleApplyDamage(msgOOB);
 	CombatManagerKw.popListMode();
 end

--- a/strings/strings_kw.xml
+++ b/strings/strings_kw.xml
@@ -13,6 +13,7 @@
 	<string name="option_label_MROT">Mark unit reactions on out of turn tests</string>
 	<string name="option_label_DROT">Display reaction message when unit rolls out-of-turn</string>
 	<string name="option_label_DSCT">CT: Demon Soul Count</string>
+	<string name="option_label_AAUS">Auto-update unit stats when experience, equipment, or type change</string>
 
 	<string name="library_recordtype_label_unit">Units</string>
 	<string name="library_recordtype_empty_unit">&#171; New Unit &#187;</string>


### PR DESCRIPTION
Added a game option that, when enabled, makes it so that when you adjust a unit's experience or armor level, or type, the stats adjust based on the charts in the book.