### PR TITLE
Column stringcycler fix

### DIFF
--- a/common/scripts/column_cycler.lua
+++ b/common/scripts/column_cycler.lua
@@ -19,28 +19,39 @@ function onInit()
 end
 
 function update(bReadOnly, bForceHide)
-	local bLocalShow;
-	if bForceHide then
-		bLocalShow = false;
-	else
-		bLocalShow = true;
-	end
-	
-	setReadOnly(bReadOnly);
-	setVisible(bLocalShow);
-	
-	local sLabel = getName() .. "_label";
-	if window[sLabel] then
-		window[sLabel].setVisible(bLocalShow);
-	end
-	if separator then
-		if window[separator[1]] then
-			window[separator[1]].setVisible(bLocalShow);
+	-- CoreRPG was updated so that whne cyclers change value, it calls self.update through a DB handler
+	-- However we use update() to manage readonly/visibility, like every other window control
+	-- So we need to process vis/readonly updates when bReadOnly isn't a databasenode
+	-- But still need to call super.update() when it is, since stringcycler now also uses update()
+	-- bReadOnly is a DB Node because of the line DB.addHandler(_sSource, "onUpdate", self.update);
+	if type(bReadOnly) ~= "databasenode" then
+		local bLocalShow;
+		if bForceHide then
+			bLocalShow = false;
+		else
+			bLocalShow = true;
+		end
+		
+		setReadOnly(bReadOnly);
+		setVisible(bLocalShow);
+		
+		local sLabel = getName() .. "_label";
+		if window[sLabel] then
+			window[sLabel].setVisible(bLocalShow);
+		end
+		if separator then
+			if window[separator[1]] then
+				window[separator[1]].setVisible(bLocalShow);
+			end
+		end
+
+		if self.onVisUpdate then
+			self.onVisUpdate(bLocalShow, bReadOnly);
 		end
 	end
-	
-	if self.onVisUpdate then
-		self.onVisUpdate(bLocalShow, bReadOnly);
+
+	if super.update then
+		super.update();
 	end
 	
 	return bLocalShow;

--- a/extension.xml
+++ b/extension.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root version="3.3" release="1.0">
-	<announcement text="Loaded Kingdoms and Warfare extension v2.1.7" font="emotefont" />
+	<announcement text="Loaded Kingdoms and Warfare extension v2.1.8" font="emotefont" />
 	<properties>
 		<name>Kingdoms and Warfare</name>
-		<version>v2.1.7</version>
+		<version>v2.1.8</version>
 		<author>Shane Parker and George Taray</author>
 		<description>Support for MCDM's Kingdom and Warfare supplement</description>
 		<ruleset>


### PR DESCRIPTION
CoreRPG updated stringcyclers a few weeks ago to call update through an onUpdate DB handler. This meant that our update() function was getting a databasenode passed to it and not the boolean it expected. So now we have to check if the argument is a boolean or not and process accordingly.

A better solution might have been to make the K&W function a different name, but every other window control uses an update(bool, bool) function to show/hide itself. This is a case of CoreRPG stringcycler breaking that rule.